### PR TITLE
Bug Fix in tryCatch 

### DIFF
--- a/R/iterate_model.R
+++ b/R/iterate_model.R
@@ -123,9 +123,11 @@ iterate_model <- function(core, params, save_years = NULL, save_vars = NULL) {
       single_param_vals <- params[i, ]
       single_param_vals <- setNames(single_param_vals, colnames(params))
       set_params(core, single_param_vals)
+
     } else {
       params_i <- unlist(params[i, ])
       set_params(core, params_i)
+
     }
 
     tryCatch(
@@ -148,16 +150,16 @@ iterate_model <- function(core, params, save_years = NULL, save_vars = NULL) {
       },
       # if Hector crashes because of parameter combinations, send error message
       error = function(e) {
-        message("An error occurred", i)
+        message("An error occurred run_number: ", i)
       }
     )
 
     # Create a placeholder dataframe for the run if there's no data collected
     if (length(result_list) < i) {
       dat <- data.frame(
-        scenario = rep(core$name, each = length(save_years)),
-        year = save_years,
-        variable = rep(save_vars, each = length(save_years)),
+        scenario = core$name,
+        year = NA,
+        variable = NA,
         value = NA,
         units = NA,
         run_number = i

--- a/tests/testthat/test-iterate_model.R
+++ b/tests/testthat/test-iterate_model.R
@@ -1,1 +1,46 @@
 # Testing iterate_model
+library(hector)
+
+# Define a set of parameters that we know should work.
+param_values <- data.frame("BETA" = c(0.54, 0.48),
+                           "Q10_RH" = c(1.4, 1.3),
+                           "NPP_FLUX0" = c(59.2, 53),
+                           "AERO_SCALE" = c(1.3, 0.93),
+                           "DIFFUSIVITY" = c(2.1, 1),
+                           "ECS" = c(2.4, 3.7))
+
+# Set up the hector core.
+ini <- system.file("input/hector_ssp245.ini", package = "hector")
+hc <- newcore(ini)
+
+test_that("iterate model runs", {
+
+  # Confirm that the default parameter values are returned from a run.
+  rslts <- iterate_model(core = hc, params = param_values)
+  expect_true(length(unique(rslts$run_number))  == 2)
+  defualt_vars <- c("CO2_concentration", "RF_tot", "RF_CO2", "global_tas")
+  expect_true(all(defualt_vars %in% rslts$variable))
+  expect_true(sum(!rslts$variable %in% defualt_vars) == 0)
+
+  # Confirm that changing default arguments is reflected in output
+  yr <- 1900
+  rslts <- iterate_model(core = hc, params = param_values, save_years = yr)
+  expect_true(unique(rslts$year) == yr)
+
+  var <- NPP()
+  rslts <- iterate_model(core = hc, params = param_values,
+                         save_years = yr, save_vars = var)
+  expect_true(unique(rslts$variable) == var)
+
+})
+
+test_that("iterate model runs even with an error", {
+
+  # Intentionally pass a parameter value that will cause Hector to crash.
+  param_values$DIFFUSIVITY[2] <- -1
+
+  # Function should run without error and return a data frame.
+  rslts <- iterate_model(core = hc, params = param_values)
+  expect_true(is.data.frame(rslts))
+
+})


### PR DESCRIPTION
Hi @jk-brown I was trying to use `matilda` for a Hector related EPA project and kept on running into an error that caused the `iterate_model` function to break down, the error function implemented within the iterate run tryCatch was also throwing an error due to columns in the data.frame being different lengths. 

In this PR made a change to the tryCatch statement and then wrote some unit tests to make sure `iterate_model` works as expected and even when don't expect it to work. 


To recreate the error 
```
# Define a set of parameters that we know should work.
param_values <- data.frame("BETA" = c(0.54, 0.48),
                           "Q10_RH" = c(1.4, 1.3),
                           "NPP_FLUX0" = c(59.2, 53),
                           "AERO_SCALE" = c(1.3, 0.93),
                           "DIFFUSIVITY" = c(2.1, 1),
                           "ECS" = c(2.4, 3.7))

# Set up the hector core.
ini <- system.file("input/hector_ssp245.ini", package = "hector")
hc <- newcore(ini)

# Intentionally pass a parameter value that will cause Hector to crash.
param_values$DIFFUSIVITY[2] <- -1
rslts <- iterate_model(core = hc, params = param_values)
```
Throws the following error message
```
An error occurred2
Error in data.frame(scenario = rep(core$name, each = length(save_years)),  : 
  arguments imply differing number of rows: 556, 0, 1
```
